### PR TITLE
Support custom stringify options

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 36702,
-    "minified": 18965,
-    "gzipped": 5716
+    "bundled": 37252,
+    "minified": 19287,
+    "gzipped": 5773
   },
   "dist/index.es.js": {
-    "bundled": 36355,
-    "minified": 18677,
-    "gzipped": 5645,
+    "bundled": 36905,
+    "minified": 18999,
+    "gzipped": 5706,
     "treeshaked": {
       "rollup": {
         "code": 75,

--- a/src/client.js
+++ b/src/client.js
@@ -18,6 +18,7 @@ export class ApiClient {
       ssrMode: typeof window === 'undefined',
       formatError: null,
       formatErrors: null,
+      stringify: null,
       serialize: (type, data, schema) => {
         return new Serializer({ schema }).serialize(type, data)
       },
@@ -111,9 +112,16 @@ export class ApiClient {
     return false
   }
 
+  createQuery(options) {
+    return new Query({
+      stringify: this.config.stringify,
+      ...options,
+    })
+  }
+
   getQuery(query) {
     if (!(query instanceof Query)) {
-      query = new Query({ key: query })
+      query = this.createQuery({ key: query })
     }
 
     if (!query.url) {
@@ -198,7 +206,7 @@ export class ApiClient {
   }
 
   async mutate(queryArg, data, config = {}) {
-    const query = new Query({ key: queryArg })
+    const query = this.createQuery({ key: queryArg })
 
     const { type, relationships } = getTypeMap(query, this.schema, data)
 
@@ -358,7 +366,7 @@ export class ApiClient {
   hydrate(queries = []) {
     const timestamp = new Date().getTime()
     queries.forEach(([key, cache]) => {
-      this.cache.push(new Query({ key, cache, timestamp }))
+      this.cache.push(this.createQuery({ key, cache, timestamp }))
     })
   }
 }

--- a/src/functions.js
+++ b/src/functions.js
@@ -16,11 +16,12 @@ export function toArray(val) {
   return Array.isArray(val) ? val : [val]
 }
 
-export function stringify(params) {
+export function stringify(params, options) {
   return qs(params, {
     sort: (a, b) => a.localeCompare(b),
     arrayFormat: 'comma',
     encodeValuesOnly: true,
+    ...options,
   })
 }
 
@@ -64,7 +65,7 @@ export function parseSchema(schema = {}) {
   }, {})
 }
 
-export function parseQueryArg(arg) {
+export function parseQueryArg(arg, options = {}) {
   if (!arg) {
     return {}
   }
@@ -83,7 +84,12 @@ export function parseQueryArg(arg) {
   let url = `/${keys.join('/')}`
 
   if (params) {
-    url += `?${stringify(params)}`
+    url += '?'
+    if (typeof options.stringify === 'function') {
+      url += options.stringify(params, stringify)
+    } else {
+      url += stringify(params, options.stringify)
+    }
   } else {
     params = {}
   }

--- a/src/query.js
+++ b/src/query.js
@@ -1,13 +1,13 @@
 import { parseQueryArg } from './functions'
 
 export class Query {
-  constructor({ key, cache, timestamp } = {}) {
+  constructor({ key, cache, timestamp, stringify } = {}) {
     this.key = key
     this.cache = cache
     this.timestamp = timestamp
     this.cacheTime = 0
     this.subscribers = []
-    Object.assign(this, parseQueryArg(key))
+    Object.assign(this, parseQueryArg(key, { stringify }))
   }
 
   subscribe(subscriber) {


### PR DESCRIPTION
- Adds a `stringify` option to `ApiClient` class.  
- If value is an object, it is treated as a option override for the call to `qs.stringify`.
- If value is a function, it is called in place of `qs.stringify`, and given the object to stringify, as well as a reference to the internal `stringify` function to support more complex stringification requirements such as different options depending on query key.