### PR TITLE
Add a "type" property for each item in the normalized data

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,11 @@ Gets normalized to...
 ```javascript
 {
   id: "1",
+  type: "todos",
   title: "Clean the kitchen!",
   user: {
     id: "2",
+    type: users",
     name: "Steve"
   }
 }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -135,6 +135,7 @@ export class Serializer {
     data = data.map(rec => {
       const attrs = {
         id: rec.id,
+        type: rec.type,
         ...rec.attributes,
       }
 

--- a/src/tests/serializer.test.js
+++ b/src/tests/serializer.test.js
@@ -113,10 +113,12 @@ describe('deserialize', () => {
     expect(result).toEqual({
       data: {
         id: '1',
+        type: 'todos',
         title: 'Clean the kitchen!',
         created: '2020-01-01T00:00:00.000Z',
         user: {
           id: '2',
+          type: 'users',
           name: 'Steve',
         },
       },


### PR DESCRIPTION
In cases where multiple document types can be returned and included for one relationship, it's currently difficult to see what data type a document has if it can be one of many without checking for the presence or absence of specific fields which would be brittle.