### PR TITLE
Made additional data available to schema resolve() functions

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -149,7 +149,7 @@ export class Serializer {
           }
 
           if (typeof ref.resolve === 'function') {
-            attrs[field] = ref.resolve(attrs[field], attrs)
+            attrs[field] = ref.resolve(attrs[field], attrs, rec)
           }
         }
       }


### PR DESCRIPTION
There are cases where a consumer of the API client might need access to data stored in a related entity's `links` or `meta` objects. Currently there is no way to access that.

Passing the unchanged data object representing a related entity to the schema resolve() functions should allow developers to access this data and expose it as fields output by the client without introducing backwards compatibility issues.