### PR TITLE
Update peerDependencies for React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "publish": "npm publish"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.6"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.6 || ^17.0.0"
   },
   "dependencies": {
     "@types/react": "^16.8.0",


### PR DESCRIPTION
Because of outdated peer dependencies,`npm install` fails (on npm v7+) if you are using React 17. A `--force` flag ignores the peer dependency and it works just fine, but this PR will make the library install to a React 17 project with no errors or flags needed, which is especially helpful in continuous integration scenarios where you don't want to force install all packages.