### PR TITLE
Add typing support for initialData

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -102,6 +102,7 @@ declare module 'jsonapi-react' {
       staleTime?: number
       ssr?: boolean
       client?: ApiClient
+      initialData?: TData
     }
   ): IResult<TData>
 }


### PR DESCRIPTION
This PR is to fix the following bug 🐛 found when using the `useQuery` method 👍 

```
Argument of type '{ initialData: string; }' is not assignable to parameter of type '{ cacheTime?: number | undefined; staleTime?: number | undefined; ssr?: boolean | undefined; client?: ApiClient | undefined; }
```